### PR TITLE
Fixed Struct extrusion and added Struct boundary function

### DIFF
--- a/lib/plasm-fun.js
+++ b/lib/plasm-fun.js
@@ -191,7 +191,7 @@
           !(item instanceof plasm.Struct)) {
         transformations = COMP2([transformations, item]);
       } else {
-        temp.push(APPLY([transformations, item]).clone());
+        //temp.push(APPLY([transformations, item]).clone());
         objects.push(APPLY([transformations, item]));
       }
     });

--- a/lib/plasm.js
+++ b/lib/plasm.js
@@ -1199,18 +1199,39 @@
    */
 
   plasm.Struct.prototype.extrude = function (hlist) {
-    var struct = new plasm.Struct;
+    var newStruct = new plasm.Struct;
 
     this.models.forEach(function (model) {
-      struct.models.push(model.extrude(hlist));
+      newStruct.models.push(model.extrude(hlist));
     });
 
     this.structs.forEach(function (struct) {
-      struct.structs.push(struct.extrude(hlist));
+      newStruct.structs.push(struct.extrude(hlist));
     });
 
-    return struct;
+    return newStruct;
   };
+
+  /**
+   * boundary
+   * 
+   * @return {plasm.Struct} boundary
+   * @api public
+   */
+
+   plasm.Struct.prototype.boundary = function () {
+    var boundary = new plasm.Struct;
+    
+    this.models.forEach(function (model) {
+      boundary.models.push(model.boundary());
+    });
+    
+    this.structs.forEach(function (struct) {
+      boundary.models.push(struct.boundary());
+    });
+
+    return boundary;
+   };
 
   /**
    * SimplicialComplex


### PR DESCRIPTION
The Struct extrusion had a conflict name with the returned element so extruding a Struct will only extrude the models in the Struct and not the other structs within it.
